### PR TITLE
FIX job guarantee page

### DIFF
--- a/src/data/context-rules.mdc
+++ b/src/data/context-rules.mdc
@@ -1,5 +1,0 @@
----
-description: 
-globs: 
-alwaysApply: false
----

--- a/src/templates/job-guarantee.js
+++ b/src/templates/job-guarantee.js
@@ -628,12 +628,7 @@ const JobGuarantee = ({ data, pageContext, yml }) => {
       <ChooseYourProgram
         id="choose-program"
         lang={pageContext.lang}
-        programs={data.allChooseYourProgramYaml.edges[0].node.programs.filter(
-          (p) =>
-            p.title === "Coding Bootcamp" ||
-            p.title === "Data Science and ML" ||
-            p.title === "CyberSecurity Bootcamp"
-        )}
+        programs={data.allChooseYourProgramYaml.edges[0].node.programs}
         title={yml.choose_program?.title}
         paragraph={yml.choose_program?.paragraph}
         background={Colors.veryLightBlue3}


### PR DESCRIPTION
- Se eliminó el filtro por nombre en la prop `programs` del componente `ChooseYourProgram` en `job-guarantee.js`.
- Ahora se muestran todos los programas definidos en el YAML.
- Se asegura consistencia entre páginas ante futuros cambios de nombre.
